### PR TITLE
Move Cursor rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,3 @@
----
-description:
-globs:
-alwaysApply: true
----
-
 This codebase contains Scaffold-ETH 2 (SE-2), everything you need to build dApps on Ethereum. Its tech stack is NextJS, RainbowKit, Wagmi and Typescript. Supports Hardhat and Foundry.
 
 It's a yarn monorepo that contains two main packages:


### PR DESCRIPTION
Rename `.cursor/rules/scaffold-eth.mdc` to `AGENTS.md` for better cross-platform useability.

FAQ: https://agents.md/

refs https://github.com/scaffold-eth/scaffold-eth-2/discussions/1220