### PR TITLE
Display checked in builders count from BatchRegistry contract

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -6,10 +6,11 @@ import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
-  const { data: checkedInCount } = useScaffoldReadContract({
+  const { data: checkedInCount, isLoading } = useScaffoldReadContract({
     contractName: "BatchRegistry",
     functionName: "checkedInCounter",
   });
+
   return (
     <>
       <div className="flex items-center flex-col grow pt-10">
@@ -21,7 +22,11 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>{checkedInCount?.toString() || "0"}</span>
+            {isLoading ? (
+              <span className="loading loading-spinner loading-sm"></span>
+            ) : (
+              <span>{checkedInCount?.toString()}</span>
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
## Description

Display the checked-in builders count dynamically on the homepage by reading the `checkedInCounter` state variable from the `BatchRegistry` smart contract using the `useScaffoldReadContract` hook.

**Changes:**
- Added import for `useScaffoldReadContract` hook from `~~/hooks/scaffold-eth`
- Initialized the hook to read `checkedInCounter` from the `BatchRegistry` contract
- Updated the display to show the live count instead of "To Be Implemented"

## Related Issues

Resolves #8 

Your ENS/address: thisbetom.eth

<img width="544" height="237" alt="image" src="https://github.com/user-attachments/assets/c407a2c9-94ff-4bb2-a8b9-fbaf7fd23e0b" />
