### PR TITLE
Fixed the margin issue of Shrestha's builder page

### DIFF
--- a/packages/nextjs/app/builders/0x8BDaC51ba5E154c14617Ee434755e08A8BbC9aa7/page.tsx
+++ b/packages/nextjs/app/builders/0x8BDaC51ba5E154c14617Ee434755e08A8BbC9aa7/page.tsx
@@ -61,7 +61,7 @@ const PageOfShrestha: NextPage = () => {
             {["DeFi", "Smart Contract Auditing"].map(interest => (
               <li
                 key={interest}
-                className="rounded-md bg-purple-50 px-2 py-1 text-xs text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                className="mb-4 rounded-md bg-purple-50 px-2 py-1 text-xs text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
               >
                 {interest}
               </li>


### PR DESCRIPTION
## Description

In Shrestha's builder page, there's a small but odd margin issue between the Interests section and the horizontal line. 
This pr resolves that issue.

#
- ### Before (with that margin issue) :
<img width="1920" height="1020" alt="Screenshot 2026-01-11 145932" src="https://github.com/user-attachments/assets/ac1195a6-8b64-4d89-aff5-1c86a55f6fd3" />

- ### After (added proper bottom margin) :
<img width="1920" height="1020" alt="Screenshot 2026-01-11 144700" src="https://github.com/user-attachments/assets/914367ff-33c6-4c35-9f63-e2fa75ff52b4" />


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) 
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Address

My address: 0x8BDaC51ba5E154c14617Ee434755e08A8BbC9aa7
